### PR TITLE
Add domain entities for Emoji Memory game

### DIFF
--- a/UI/EmojiMemory.UI.Domain/Entities/Card.cs
+++ b/UI/EmojiMemory.UI.Domain/Entities/Card.cs
@@ -1,0 +1,12 @@
+namespace EmojiMemory.UI.Domain.Entities
+{
+    using EmojiMemory.UI.Domain.Enums;
+    using EmojiMemory.UI.Domain.ValueObjects;
+
+    public class Card
+    {
+        public EmojiId Emoji { get; init; } = new EmojiId(string.Empty);
+        public Position Position { get; init; } = new Position(0, 0);
+        public CardState State { get; set; } = CardState.FaceDown;
+    }
+}

--- a/UI/EmojiMemory.UI.Domain/Entities/GameBoard.cs
+++ b/UI/EmojiMemory.UI.Domain/Entities/GameBoard.cs
@@ -1,0 +1,12 @@
+namespace EmojiMemory.UI.Domain.Entities
+{
+    using EmojiMemory.UI.Domain.Enums;
+    using EmojiMemory.UI.Domain.ValueObjects;
+
+    public class GameBoard
+    {
+        public GridSize GridSize { get; init; } = new GridSize(4, 4);
+        public List<Card> Cards { get; init; } = new();
+        public GameState State { get; set; } = GameState.NotStarted;
+    }
+}

--- a/UI/EmojiMemory.UI.Domain/Entities/GameSession.cs
+++ b/UI/EmojiMemory.UI.Domain/Entities/GameSession.cs
@@ -1,0 +1,12 @@
+namespace EmojiMemory.UI.Domain.Entities
+{
+    using EmojiMemory.UI.Domain.Enums;
+
+    public class GameSession
+    {
+        public GameBoard Board { get; init; } = new GameBoard();
+        public ScoreBoard ScoreBoard { get; init; } = new ScoreBoard();
+        public Player Player { get; init; } = new Player();
+        public GameState State { get; set; } = GameState.NotStarted;
+    }
+}

--- a/UI/EmojiMemory.UI.Domain/Entities/Player.cs
+++ b/UI/EmojiMemory.UI.Domain/Entities/Player.cs
@@ -1,0 +1,7 @@
+namespace EmojiMemory.UI.Domain.Entities
+{
+    public class Player
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/UI/EmojiMemory.UI.Domain/Entities/ScoreBoard.cs
+++ b/UI/EmojiMemory.UI.Domain/Entities/ScoreBoard.cs
@@ -1,0 +1,8 @@
+namespace EmojiMemory.UI.Domain.Entities
+{
+    public class ScoreBoard
+    {
+        public int Moves { get; set; } = 0;
+        public TimeSpan TimeElapsed { get; set; } = TimeSpan.Zero;
+    }
+}


### PR DESCRIPTION
## Summary
- add `GameBoard` entity with board state and size
- add `Card` entity with default face‑down state
- add `ScoreBoard` entity to track moves and time
- add `GameSession` entity to orchestrate board, scoreboard and player
- add `Player` entity

## Testing
- `dotnet build EmojiMemory.sln` *(fails: unable to restore packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685563f8f9ac83298f8de19377c630de