### PR TITLE
Handle card clicks in game view

### DIFF
--- a/UI/EmojiMemory.UI/Pages/Game.razor
+++ b/UI/EmojiMemory.UI/Pages/Game.razor
@@ -33,6 +33,7 @@
   [Parameter]
   [SupplyParameterFromQuery] public int Cols { get; set; } = 4;
 
+  private bool boardLocked = false;
   private static readonly string[] EmojiPool = new[] { "🐶", "🍕", "🚀", "🐸", "🎈", "🎮", "🎁", "🧠", "🐱", "🍩" };
 
   protected override void OnInitialized()
@@ -53,6 +54,21 @@
 
   private async Task OnCardClicked(Card clicked)
   {
+    if (boardLocked || clicked.State != CardState.FaceDown)
+    {
+      return;
+    }
 
+    GameEngine.FlipCard(clicked.Position);
+    StateHasChanged();
+
+    if (GameEngine.Session.Board.Cards.Count(c => c.State == CardState.FaceUp) == 2)
+    {
+      boardLocked = true;
+      await Task.Delay(750);
+      GameEngine.EvaluateFlip();
+      boardLocked = false;
+      StateHasChanged();
+    }
   }
 }


### PR DESCRIPTION
## Summary
- handle card click events by updating the `GameEngineService`
- block further clicks while evaluating flips

## Testing
- `dotnet build EmojiMemory.sln --no-restore` *(fails: assets file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68562d0d3b7883299b449ece4afe8da9