### PR TITLE
Add pause/resume game button

### DIFF
--- a/Test/EmojiMemory.Tests.UnitTests/UI.Application/Services/GameEngineServiceTests.cs
+++ b/Test/EmojiMemory.Tests.UnitTests/UI.Application/Services/GameEngineServiceTests.cs
@@ -79,4 +79,29 @@ public class GameEngineServiceTests
         Assert.Equal(GameState.Completed, engine.Session.State);
         Assert.Equal(GameState.Completed, engine.Session.Board.State);
     }
+
+    [Fact]
+    public void PauseGame_SetsStateToPaused()
+    {
+        var engine = new GameEngineService();
+        engine.StartGame(new GridSize(2, 2), _emojis.Take(2));
+
+        engine.PauseGame();
+
+        Assert.Equal(GameState.Paused, engine.Session.State);
+        Assert.Equal(GameState.Paused, engine.Session.Board.State);
+    }
+
+    [Fact]
+    public void ResumeGame_FromPaused_SetsStateToInProgress()
+    {
+        var engine = new GameEngineService();
+        engine.StartGame(new GridSize(2, 2), _emojis.Take(2));
+        engine.PauseGame();
+
+        engine.ResumeGame();
+
+        Assert.Equal(GameState.InProgress, engine.Session.State);
+        Assert.Equal(GameState.InProgress, engine.Session.Board.State);
+    }
 }

--- a/UI/EmojiMemory.UI/Components/PauseResumeButton.razor
+++ b/UI/EmojiMemory.UI/Components/PauseResumeButton.razor
@@ -1,0 +1,20 @@
+@inject EmojiMemory.UI.Application.Services.GameEngineService GameEngine
+@using EmojiMemory.UI.Domain.Enums
+
+<button class="pause-button" @onclick="Toggle">@Label</button>
+
+@code {
+    private string Label => GameEngine.Session.State == GameState.Paused ? "Resume" : "Pause";
+
+    private void Toggle()
+    {
+        if (GameEngine.Session.State == GameState.Paused)
+        {
+            GameEngine.ResumeGame();
+        }
+        else if (GameEngine.Session.State == GameState.InProgress)
+        {
+            GameEngine.PauseGame();
+        }
+    }
+}

--- a/UI/EmojiMemory.UI/Components/PauseResumeButton.razor.css
+++ b/UI/EmojiMemory.UI/Components/PauseResumeButton.razor.css
@@ -1,0 +1,14 @@
+.pause-button {
+  display: inline-block;
+  background-color: #f0f0f0;
+  padding: 0.4rem 1rem;
+  border: none;
+  border-radius: 12px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.pause-button:hover {
+  background-color: #e0e0e0;
+}

--- a/UI/EmojiMemory.UI/Pages/Game.razor
+++ b/UI/EmojiMemory.UI/Pages/Game.razor
@@ -10,7 +10,10 @@
   <div class="game-container">
     @if (GameEngine.Session.State != GameState.NotStarted)
     {
-      <Timer />
+      <div class="game-controls">
+        <Timer />
+        <PauseResumeButton />
+      </div>
     }
     @if (GameEngine.Session.Board.Cards.Count <= 0)
     {
@@ -58,7 +61,9 @@
 
   private async Task OnCardClicked(Card clicked)
   {
-    if (boardLocked || clicked.State != CardState.FaceDown)
+    if (boardLocked ||
+        GameEngine.Session.State != GameState.InProgress ||
+        clicked.State != CardState.FaceDown)
     {
       return;
     }

--- a/UI/EmojiMemory.UI/Pages/Game.razor.css
+++ b/UI/EmojiMemory.UI/Pages/Game.razor.css
@@ -29,3 +29,10 @@
     background-color: #c8e6c9;
     cursor: default;
   }
+
+.game-controls {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- add PauseResumeButton component
- use PauseResumeButton on game page
- lock board interaction when the game is paused
- style for PauseResumeButton and game controls
- add tests for pause and resume logic

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68564bd7bb608329bc4f4d9faf231f53