### PR TITLE
Update pause/resume button style and text

### DIFF
--- a/UI/EmojiMemory.UI/Components/PauseResumeButton.razor
+++ b/UI/EmojiMemory.UI/Components/PauseResumeButton.razor
@@ -4,7 +4,7 @@
 <button class="pause-button" @onclick="Toggle">@Label</button>
 
 @code {
-    private string Label => GameEngine.Session.State == GameState.Paused ? "Resume" : "Pause";
+    private string Label => GameEngine.Session.State == GameState.Paused ? "▶️" : "⏸️";
 
     private void Toggle()
     {

--- a/UI/EmojiMemory.UI/Components/PauseResumeButton.razor.css
+++ b/UI/EmojiMemory.UI/Components/PauseResumeButton.razor.css
@@ -1,14 +1,14 @@
 .pause-button {
-  display: inline-block;
-  background-color: #f0f0f0;
-  padding: 0.4rem 1rem;
+  background-color: #4caf50;
+  color: white;
+  font-size: 1.1rem;
+  padding: 0.75rem 2rem;
   border: none;
   border-radius: 12px;
-  font-size: 1rem;
   cursor: pointer;
   transition: background-color 0.2s ease-in-out;
 }
 
 .pause-button:hover {
-  background-color: #e0e0e0;
+  background-color: #388e3c;
 }


### PR DESCRIPTION
## Summary
- style the pause/resume button to match start screen buttons
- swap text labels for play/pause emojis

## Testing
- `dotnet test` *(fails: Unable to load the service index for nuget)*

------
https://chatgpt.com/codex/tasks/task_e_68564e585c608329aa486b0f334f9166