### PR TITLE
Add GameOver overlay

### DIFF
--- a/UI/EmojiMemory.UI/Components/GameOver.razor
+++ b/UI/EmojiMemory.UI/Components/GameOver.razor
@@ -1,0 +1,37 @@
+@inject EmojiMemory.UI.Application.Services.GameEngineService GameEngine
+
+<div class="game-over-overlay">
+  <div class="game-over-box">
+    <h2>Game Over!</h2>
+    <p>You matched all the cards!</p>
+    <p class="stats">
+      Time: @GameEngine.Session.ScoreBoard.TimeElapsed.ToString(@"mm\:ss")<br />
+      Moves: @GameEngine.Session.ScoreBoard.Moves
+    </p>
+    <div class="buttons">
+      <button class="play-again" @onclick="OnPlayAgainClicked">Play Again</button>
+      <button class="back-menu" @onclick="OnBackToMenuClicked">Back to Menu</button>
+    </div>
+  </div>
+</div>
+
+@code {
+    [Parameter] public EventCallback OnPlayAgain { get; set; }
+    [Parameter] public EventCallback OnBackToMenu { get; set; }
+
+    private async Task OnPlayAgainClicked()
+    {
+        if (OnPlayAgain.HasDelegate)
+        {
+            await OnPlayAgain.InvokeAsync();
+        }
+    }
+
+    private async Task OnBackToMenuClicked()
+    {
+        if (OnBackToMenu.HasDelegate)
+        {
+            await OnBackToMenu.InvokeAsync();
+        }
+    }
+}

--- a/UI/EmojiMemory.UI/Components/GameOver.razor.css
+++ b/UI/EmojiMemory.UI/Components/GameOver.razor.css
@@ -1,0 +1,52 @@
+.game-over-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.game-over-box {
+  background-color: #ffffff;
+  padding: 2rem;
+  border-radius: 12px;
+  text-align: center;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+}
+
+.game-over-box h2 {
+  margin-bottom: 0.5rem;
+}
+
+.game-over-box .stats {
+  margin: 1rem 0;
+  font-weight: bold;
+}
+
+.game-over-box .buttons {
+  margin-top: 1rem;
+}
+
+.game-over-box button {
+  margin: 0 0.5rem;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.play-again {
+  background-color: #4caf50;
+  color: white;
+}
+
+.back-menu {
+  background-color: #f44336;
+  color: white;
+}

--- a/UI/EmojiMemory.UI/Pages/Game.razor
+++ b/UI/EmojiMemory.UI/Pages/Game.razor
@@ -30,7 +30,11 @@
           </button>
         }
       </div>
-    }
+      @if (GameEngine.Session.State == GameState.Completed)
+      {
+        <GameOver OnPlayAgain="StartNewGame" OnBackToMenu="GoToMenu" />
+      }
+      }
   </div>
 
 @code {
@@ -79,5 +83,16 @@
       boardLocked = false;
       StateHasChanged();
     }
+  }
+
+  private void StartNewGame()
+  {
+    InitializeGame();
+    StateHasChanged();
+  }
+
+  private void GoToMenu()
+  {
+    NavigationManager.NavigateTo("/");
   }
 }


### PR DESCRIPTION
## Summary
- detect game completion in `Game.razor`
- show a new `GameOver` component with final time and moves
- include buttons to replay or return to the menu

## Testing
- `dotnet test --no-build` *(fails: unable to restore packages)*

------
https://chatgpt.com/codex/tasks/task_e_685651cb49a4832992bface35a9dd14f