### PR TITLE
Add highscore abstraction and local storage implementation

### DIFF
--- a/EmojiMemory.UI.Infrastructure/EmojiMemory.UI.Infrastructure.csproj
+++ b/EmojiMemory.UI.Infrastructure/EmojiMemory.UI.Infrastructure.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="../UI/EmojiMemory.UI.Application/EmojiMemory.UI.Application.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/EmojiMemory.UI.Infrastructure/Storage/LocalStorageHighscore.cs
+++ b/EmojiMemory.UI.Infrastructure/Storage/LocalStorageHighscore.cs
@@ -1,0 +1,30 @@
+using Microsoft.JSInterop;
+using EmojiMemory.UI.Application.Contracts;
+
+namespace EmojiMemory.UI.Infrastructure.Storage;
+
+public class LocalStorageHighscore : IHighscore
+{
+    private readonly IJSRuntime _jsRuntime;
+    private const string Key = "highscore";
+
+    public LocalStorageHighscore(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    public async ValueTask SaveScoreAsync(int score)
+    {
+        await _jsRuntime.InvokeVoidAsync("localStorage.setItem", Key, score.ToString());
+    }
+
+    public async ValueTask<int?> GetScoreAsync()
+    {
+        var result = await _jsRuntime.InvokeAsync<string?>("localStorage.getItem", Key);
+        if (int.TryParse(result, out var value))
+        {
+            return value;
+        }
+        return null;
+    }
+}

--- a/UI/EmojiMemory.UI.Application/Contracts/IHighscore.cs
+++ b/UI/EmojiMemory.UI.Application/Contracts/IHighscore.cs
@@ -1,0 +1,8 @@
+namespace EmojiMemory.UI.Application.Contracts
+{
+    public interface IHighscore
+    {
+        ValueTask SaveScoreAsync(int score);
+        ValueTask<int?> GetScoreAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- define `IHighscore` contract in UI.Application
- implement `LocalStorageHighscore` in UI.Infrastructure using `IJSRuntime`
- reference Application project from Infrastructure

## Testing
- `dotnet build EmojiMemory.sln -c Release` *(fails: unable to load the service index)*
- `dotnet test` *(fails: unable to load the service index)*

------
https://chatgpt.com/codex/tasks/task_e_685653fc030083298aec7dc369c5a5bb