### PR TITLE
Introduce HighscoreEntry record for persistent scores

### DIFF
--- a/UI/EmojiMemory.UI.Application/Contracts/IHighscore.cs
+++ b/UI/EmojiMemory.UI.Application/Contracts/IHighscore.cs
@@ -1,8 +1,10 @@
+using EmojiMemory.UI.Domain.Entities;
+
 namespace EmojiMemory.UI.Application.Contracts
 {
     public interface IHighscore
     {
-        ValueTask SaveScoreAsync(int score);
-        ValueTask<int?> GetScoreAsync();
+        ValueTask SaveScoreAsync(HighscoreEntry score);
+        ValueTask<HighscoreEntry?> GetScoreAsync();
     }
 }

--- a/UI/EmojiMemory.UI.Domain/Entities/HighscoreEntry.cs
+++ b/UI/EmojiMemory.UI.Domain/Entities/HighscoreEntry.cs
@@ -1,0 +1,7 @@
+namespace EmojiMemory.UI.Domain.Entities;
+
+public class HighscoreEntry
+{
+    public int Score { get; set; } = 0;
+    public TimeSpan Time { get; set; } = TimeSpan.Zero;
+}


### PR DESCRIPTION
## Summary
- add `HighscoreEntry` domain class
- update `IHighscore` to use the new class
- adjust local storage implementation to serialize/deserialize `HighscoreEntry`

## Testing
- `dotnet restore --ignore-failed-sources` *(fails: unable to reach nuget.org)*
- `dotnet test` *(fails: restore canceled due to missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68565660981483298c5c3b6d98053eb3