### PR TITLE
Add difficulty based highscores

### DIFF
--- a/Test/EmojiMemory.Tests.UnitTests/UI.Application/Services/GameEngineServiceTests.cs
+++ b/Test/EmojiMemory.Tests.UnitTests/UI.Application/Services/GameEngineServiceTests.cs
@@ -6,6 +6,7 @@ using EmojiMemory.UI.Domain.ValueObjects;
 using Xunit;
 using System.Linq;
 using System;
+using System.Collections.Generic;
 
 namespace EmojiMemory.Tests.UnitTests.UI.Application.Services;
 
@@ -13,17 +14,18 @@ public class GameEngineServiceTests
 {
     private class StubHighscore : IHighscore
     {
-        public HighscoreEntry? Stored { get; private set; }
+        public Dictionary<string, HighscoreEntry?> Stored { get; } = new();
 
-        public ValueTask SaveScoreAsync(HighscoreEntry score)
+        public ValueTask SaveScoreAsync(GridSize size, HighscoreEntry score)
         {
-            Stored = score;
+            Stored[$"{size.Rows}x{size.Columns}"] = score;
             return ValueTask.CompletedTask;
         }
 
-        public ValueTask<HighscoreEntry?> GetScoreAsync()
+        public ValueTask<HighscoreEntry?> GetScoreAsync(GridSize size)
         {
-            return ValueTask.FromResult<HighscoreEntry?>(Stored);
+            Stored.TryGetValue($"{size.Rows}x{size.Columns}", out var entry);
+            return ValueTask.FromResult(entry);
         }
     }
 

--- a/UI/EmojiMemory.UI.Application/Contracts/IHighscore.cs
+++ b/UI/EmojiMemory.UI.Application/Contracts/IHighscore.cs
@@ -2,9 +2,11 @@ using EmojiMemory.UI.Domain.Entities;
 
 namespace EmojiMemory.UI.Application.Contracts
 {
+    using EmojiMemory.UI.Domain.ValueObjects;
+
     public interface IHighscore
     {
-        ValueTask SaveScoreAsync(HighscoreEntry score);
-        ValueTask<HighscoreEntry?> GetScoreAsync();
+        ValueTask SaveScoreAsync(GridSize size, HighscoreEntry score);
+        ValueTask<HighscoreEntry?> GetScoreAsync(GridSize size);
     }
 }

--- a/UI/EmojiMemory.UI.Application/Services/GameEngineService.cs
+++ b/UI/EmojiMemory.UI.Application/Services/GameEngineService.cs
@@ -126,12 +126,13 @@ public class GameEngineService
             Time = Session.ScoreBoard.TimeElapsed
         };
 
-        var existing = await _highscore.GetScoreAsync();
+        var size = Session.Board.GridSize;
+        var existing = await _highscore.GetScoreAsync(size);
         if (existing == null ||
             current.Time < existing.Time ||
             (current.Time == existing.Time && current.Score < existing.Score))
         {
-            await _highscore.SaveScoreAsync(current);
+            await _highscore.SaveScoreAsync(size, current);
         }
     }
 

--- a/UI/EmojiMemory.UI/Components/StartScreen.razor
+++ b/UI/EmojiMemory.UI/Components/StartScreen.razor
@@ -1,5 +1,6 @@
 @inject NavigationManager NavigationManager
 @inject EmojiMemory.UI.Application.Contracts.IHighscore Highscore
+@using EmojiMemory.UI.Domain.ValueObjects
 
 <div class="start-screen">
   <div class="title-section">
@@ -9,8 +10,8 @@
   </div>
 
   <div class="difficulty-buttons">
-    <button type="button" class="easy" @onclick="() => SetDifficulty(4, 4)">Easy (4x4)</button>
-    <button type="button" class="hard" @onclick="() => SetDifficulty(5, 4)">Hard (5x4)</button>
+    <button type="button" class="easy" @onclick="@(async () => await SetDifficulty(4, 4))">Easy (4x4)</button>
+    <button type="button" class="hard" @onclick="@(async () => await SetDifficulty(5, 4))">Hard (5x4)</button>
   </div>
 
   <button type="button" class="start-button" @onclick="StartGame">Start Game (@(rows)x@(cols))</button>
@@ -31,13 +32,14 @@
 
   protected override async Task OnInitializedAsync()
   {
-    _entry = await Highscore.GetScoreAsync();
+    _entry = await Highscore.GetScoreAsync(new GridSize(rows, cols));
   }
 
-  private void SetDifficulty(int r, int c)
+  private async Task SetDifficulty(int r, int c)
   {
     rows = r;
     cols = c;
+    _entry = await Highscore.GetScoreAsync(new GridSize(rows, cols));
   }
 
   private void StartGame()


### PR DESCRIPTION
## Summary
- track highscores per board size
- show highscore for selected difficulty on the start screen
- adjust game engine and tests for new highscore API

## Testing
- `dotnet build --no-restore` *(fails: Assets file not found)*
- `dotnet test` *(fails: unable to restore packages)*

------
https://chatgpt.com/codex/tasks/task_e_685661a9ba2c832990bd35afc3fdd410