### PR TITLE
Fix pause overlay not updating

### DIFF
--- a/UI/EmojiMemory.UI.Application/Services/GameEngineService.cs
+++ b/UI/EmojiMemory.UI.Application/Services/GameEngineService.cs
@@ -14,6 +14,10 @@ public class GameEngineService
     private Card? _secondCard;
     private List<EmojiId> _emojiPool = new();
 
+    public event Action? StateChanged;
+
+    private void NotifyStateChanged() => StateChanged?.Invoke();
+
     public GameEngineService(IHighscore highscore)
     {
         _highscore = highscore;
@@ -42,6 +46,7 @@ public class GameEngineService
         _firstCard = null;
         _secondCard = null;
         BeginTimer();
+        NotifyStateChanged();
     }
 
     public void FlipCard(Position position)
@@ -91,6 +96,7 @@ public class GameEngineService
             Session.Board.State = GameState.Completed;
             StopTimer();
             await CheckHighscoreAsync();
+            NotifyStateChanged();
         }
     }
 
@@ -109,6 +115,7 @@ public class GameEngineService
         Session.State = GameState.Paused;
         Session.Board.State = GameState.Paused;
         StopTimer();
+        NotifyStateChanged();
     }
 
     public void ResumeGame()
@@ -116,6 +123,7 @@ public class GameEngineService
         Session.State = GameState.InProgress;
         Session.Board.State = GameState.InProgress;
         _stopwatch.Start();
+        NotifyStateChanged();
     }
 
     private async ValueTask CheckHighscoreAsync()

--- a/UI/EmojiMemory.UI/Pages/Game.razor
+++ b/UI/EmojiMemory.UI/Pages/Game.razor
@@ -1,4 +1,5 @@
-﻿@page "/game"
+@page "/game"
+@implements IDisposable
 @inject NavigationManager NavigationManager
 @inject EmojiMemory.UI.Application.Services.GameEngineService GameEngine
 @using EmojiMemory.UI.Domain.Entities
@@ -53,7 +54,13 @@
 
   protected override void OnInitialized()
   {
+    GameEngine.StateChanged += OnStateChanged;
     InitializeGame();
+  }
+
+  public void Dispose()
+  {
+    GameEngine.StateChanged -= OnStateChanged;
   }
 
   private void InitializeGame()
@@ -98,5 +105,10 @@
   private void GoToMenu()
   {
     NavigationManager.NavigateTo("/");
+  }
+
+  private void OnStateChanged()
+  {
+    InvokeAsync(StateHasChanged);
   }
 }


### PR DESCRIPTION
## Summary
- notify components when game state changes via new `StateChanged` event
- subscribe `Game.razor` to the event so pause/resume triggers re-render

## Testing
- `dotnet test --no-build` *(fails: unable to reach NuGet)*

------
https://chatgpt.com/codex/tasks/task_e_68566e9fdf648329ad29051f4bc21e11