### PR TITLE
Fix PauseResumeButton label update

### DIFF
--- a/UI/EmojiMemory.UI/Components/PauseResumeButton.razor
+++ b/UI/EmojiMemory.UI/Components/PauseResumeButton.razor
@@ -1,3 +1,4 @@
+@implements IDisposable
 @inject EmojiMemory.UI.Application.Services.GameEngineService GameEngine
 @using EmojiMemory.UI.Domain.Enums
 
@@ -5,6 +6,16 @@
 
 @code {
     private string Label => GameEngine.Session.State == GameState.Paused ? "▶️" : "⏸️";
+
+    protected override void OnInitialized()
+    {
+        GameEngine.StateChanged += OnStateChanged;
+    }
+
+    private void OnStateChanged()
+    {
+        InvokeAsync(StateHasChanged);
+    }
 
     private void Toggle()
     {
@@ -16,5 +27,10 @@
         {
             GameEngine.PauseGame();
         }
+    }
+
+    public void Dispose()
+    {
+        GameEngine.StateChanged -= OnStateChanged;
     }
 }


### PR DESCRIPTION
## Summary
- hook `PauseResumeButton` into `GameEngineService.StateChanged`

## Testing
- `dotnet test` *(fails: unable to restore packages)*

------
https://chatgpt.com/codex/tasks/task_e_6856710ce33c8329aa7b292c14e7849e