### PR TITLE
Prevent triple flips and adjust tests

### DIFF
--- a/Test/EmojiMemory.Tests.UnitTests/UI.Application/Services/GameEngineServiceTests.cs
+++ b/Test/EmojiMemory.Tests.UnitTests/UI.Application/Services/GameEngineServiceTests.cs
@@ -63,6 +63,24 @@ public class GameEngineServiceTests
     }
 
     [Fact]
+    public void FlipCard_ThirdCardIgnored_WhenTwoCardsFaceUp()
+    {
+        var engine = new GameEngineService(new StubHighscore());
+        engine.StartGame(new GridSize(2, 2), _emojis.Take(2));
+        var positions = engine.Session.Board.Cards.Select(c => c.Position).ToArray();
+
+        engine.FlipCard(positions[0]);
+        engine.FlipCard(positions[1]);
+
+        var third = positions[2];
+        engine.FlipCard(third);
+
+        var thirdCard = engine.Session.Board.Cards.First(c => c.Position.Equals(third));
+        Assert.Equal(CardState.FaceDown, thirdCard.State);
+        Assert.Equal(2, engine.Session.Board.Cards.Count(c => c.State == CardState.FaceUp));
+    }
+
+    [Fact]
     public void EvaluateFlip_MatchingCards_SetAsMatched()
     {
         var engine = new GameEngineService(new StubHighscore());
@@ -89,10 +107,12 @@ public class GameEngineServiceTests
         engine.StartGame(new GridSize(2, 2), _emojis.Take(2));
         var positions = engine.Session.Board.Cards.Select(c => c.Position).ToArray();
 
-        foreach (var pos in positions)
-            engine.FlipCard(pos);
-
+        engine.FlipCard(positions[0]);
+        engine.FlipCard(positions[1]);
         engine.EvaluateFlip();
+
+        engine.FlipCard(positions[2]);
+        engine.FlipCard(positions[3]);
         engine.EvaluateFlip();
 
         Assert.Equal(GameState.Completed, engine.Session.State);

--- a/UI/EmojiMemory.UI.Application/Services/GameEngineService.cs
+++ b/UI/EmojiMemory.UI.Application/Services/GameEngineService.cs
@@ -51,6 +51,11 @@ public class GameEngineService
 
     public void FlipCard(Position position)
     {
+        if (_firstCard != null && _secondCard != null)
+        {
+            return;
+        }
+
         var card = Session.Board.Cards.FirstOrDefault(c => c.Position.Equals(position));
         if (card == null || card.State != CardState.FaceDown)
         {


### PR DESCRIPTION
## Summary
- ignore extra flips when two cards are already selected
- test that a third flip does nothing
- adjust all-cards-matched test to evaluate after each pair

## Testing
- `dotnet test --no-build -v minimal` *(fails: Restore failed)*

------
https://chatgpt.com/codex/tasks/task_e_685673a49b3c8329a59071fc1b45c889