### PR TITLE
Add emoji progress bar while loading

### DIFF
--- a/UI/EmojiMemory.UI/wwwroot/css/app.css
+++ b/UI/EmojiMemory.UI/wwwroot/css/app.css
@@ -74,6 +74,13 @@
         content: var(--blazor-load-percentage-text, "Loading");
     }
 
+.emoji-progress {
+    position: absolute;
+    text-align: center;
+    font-size: 1.5rem;
+    inset: calc(20vh + 5rem) 0 auto 0;
+}
+
 code {
     color: #c02d76;
 }

--- a/UI/EmojiMemory.UI/wwwroot/index.html
+++ b/UI/EmojiMemory.UI/wwwroot/index.html
@@ -18,6 +18,7 @@
             <circle r="40%" cx="50%" cy="50%" />
         </svg>
         <div class="loading-progress-text"></div>
+        <div id="emoji-progress" class="emoji-progress"></div>
     </div>
 
     <div id="blazor-error-ui">
@@ -25,6 +26,28 @@
         <a href="." class="reload">Reload</a>
         <span class="dismiss">🗙</span>
     </div>
+    <script>
+        (function () {
+            const emojiBar = document.getElementById('emoji-progress');
+            const emoji = '🧠';
+            let lastCount = -1;
+
+            function update() {
+                const val = parseFloat(
+                    getComputedStyle(document.documentElement)
+                        .getPropertyValue('--blazor-load-percentage')
+                ) || 0;
+
+                const count = Math.floor(val / 10);
+                if (count !== lastCount) {
+                    emojiBar.textContent = emoji.repeat(count);
+                    lastCount = count;
+                }
+                requestAnimationFrame(update);
+            }
+            update();
+        })();
+    </script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- show an emoji progress bar under the loading percentage
- update styles for emoji progress
- drive the bar with a script that reads the existing Blazor progress variable

## Testing
- `dotnet test --no-build` *(fails: unable to restore packages)*

------
https://chatgpt.com/codex/tasks/task_e_6856767e5f608329b9bd55364c2638a4