### PR TITLE
Add sound effects to GameEngine

### DIFF
--- a/Test/EmojiMemory.Tests.UnitTests/UI.Application/Services/GameEngineServiceTests.cs
+++ b/Test/EmojiMemory.Tests.UnitTests/UI.Application/Services/GameEngineServiceTests.cs
@@ -25,6 +25,17 @@ public class GameEngineServiceTests
         }
     }
 
+    private class StubSoundService : ISoundService
+    {
+        public List<SoundEffect> Played { get; } = [];
+
+        public Task PlayAsync(SoundEffect soundEffect)
+        {
+            Played.Add(soundEffect);
+            return Task.CompletedTask;
+        }
+    }
+
     private static readonly EmojiId[] _emojis =
     [
         new EmojiId("😀"),
@@ -36,7 +47,7 @@ public class GameEngineServiceTests
     [Fact]
     public void StartGame_InitializesSessionWithCards()
     {
-        var engine = new GameEngineService(new StubHighscore());
+        var engine = new GameEngineService(new StubHighscore(), new StubSoundService());
         engine.StartGame(new GridSize(2, 4), _emojis.Take(4));
 
         Assert.Equal(GameState.InProgress, engine.Session.State);
@@ -48,7 +59,7 @@ public class GameEngineServiceTests
     [Fact]
     public void FlipCard_FlipsFaceDownCard()
     {
-        var engine = new GameEngineService(new StubHighscore());
+        var engine = new GameEngineService(new StubHighscore(), new StubSoundService());
         engine.StartGame(new GridSize(2, 4), _emojis.Take(4));
         var pos = engine.Session.Board.Cards.First().Position;
 
@@ -61,7 +72,7 @@ public class GameEngineServiceTests
     [Fact]
     public void FlipCard_ThirdCardIgnored_WhenTwoCardsFaceUp()
     {
-        var engine = new GameEngineService(new StubHighscore());
+        var engine = new GameEngineService(new StubHighscore(), new StubSoundService());
         engine.StartGame(new GridSize(2, 2), _emojis.Take(2));
         var positions = engine.Session.Board.Cards.Select(c => c.Position).ToArray();
 
@@ -79,7 +90,7 @@ public class GameEngineServiceTests
     [Fact]
     public async Task EvaluateFlip_MatchingCards_SetAsMatched()
     {
-        var engine = new GameEngineService(new StubHighscore());
+        var engine = new GameEngineService(new StubHighscore(), new StubSoundService());
         engine.StartGame(new GridSize(2, 4), _emojis.Take(4));
         var pair = engine.Session.Board.Cards
             .GroupBy(c => c.Emoji)
@@ -99,7 +110,7 @@ public class GameEngineServiceTests
     [Fact]
     public async Task EvaluateFlip_AllCardsMatched_EndsGame()
     {
-        var engine = new GameEngineService(new StubHighscore());
+        var engine = new GameEngineService(new StubHighscore(), new StubSoundService());
         engine.StartGame(new GridSize(2, 2), _emojis.Take(2));
         var positions = engine.Session.Board.Cards.Select(c => c.Position).ToArray();
 
@@ -118,7 +129,7 @@ public class GameEngineServiceTests
     [Fact]
     public void PauseGame_SetsStateToPaused()
     {
-        var engine = new GameEngineService(new StubHighscore());
+        var engine = new GameEngineService(new StubHighscore(), new StubSoundService());
         engine.StartGame(new GridSize(2, 2), _emojis.Take(2));
 
         engine.PauseGame();
@@ -130,7 +141,7 @@ public class GameEngineServiceTests
     [Fact]
     public void ResumeGame_FromPaused_SetsStateToInProgress()
     {
-        var engine = new GameEngineService(new StubHighscore());
+        var engine = new GameEngineService(new StubHighscore(), new StubSoundService());
         engine.StartGame(new GridSize(2, 2), _emojis.Take(2));
         engine.PauseGame();
 

--- a/UI/EmojiMemory.UI.Application/Services/GameEngineService.cs
+++ b/UI/EmojiMemory.UI.Application/Services/GameEngineService.cs
@@ -6,10 +6,11 @@ using EmojiMemory.UI.Domain.ValueObjects;
 
 namespace EmojiMemory.UI.Application.Services;
 
-public class GameEngineService(IHighscore highscore)
+public class GameEngineService(IHighscore highscore, ISoundService soundService)
 {
     private readonly Stopwatch _stopwatch = new();
     private readonly IHighscore _highscore = highscore;
+    private readonly ISoundService _soundService = soundService;
     private Card? _firstCard;
     private Card? _secondCard;
     private List<EmojiId> _emojiPool = [];
@@ -58,6 +59,7 @@ public class GameEngineService(IHighscore highscore)
         }
 
         card.State = CardState.FaceUp;
+        _ = _soundService.PlayAsync(SoundEffect.Flip);
         if (_firstCard == null)
         {
             _firstCard = card;
@@ -77,11 +79,13 @@ public class GameEngineService(IHighscore highscore)
         {
             _firstCard.State = CardState.Matched;
             _secondCard.State = CardState.Matched;
+            await _soundService.PlayAsync(SoundEffect.Match);
         }
         else
         {
             _firstCard.State = CardState.FaceDown;
             _secondCard.State = CardState.FaceDown;
+            await _soundService.PlayAsync(SoundEffect.Mismatch);
         }
 
         _firstCard = null;
@@ -93,6 +97,7 @@ public class GameEngineService(IHighscore highscore)
             Session.Board.State = GameState.Completed;
             StopTimer();
             await CheckHighscoreAsync();
+            await _soundService.PlayAsync(SoundEffect.Win);
             NotifyStateChanged();
         }
     }


### PR DESCRIPTION
## Summary
- inject `ISoundService` into `GameEngineService`
- play flip, match, mismatch and win sounds using `SoundEffect`
- adjust unit tests for new dependency

## Testing
- `dotnet test --no-build` *(fails: cannot access NuGet)*

------
https://chatgpt.com/codex/tasks/task_e_68568fec8ed88329b81ceebc5e7184fa